### PR TITLE
Implement a --dry-run option

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -77,6 +77,7 @@ class AdapterFactory
     protected $wrappers = array(
         'prefix' => 'Phinx\Db\Adapter\TablePrefixAdapter',
         'proxy'  => 'Phinx\Db\Adapter\ProxyAdapter',
+        'dryrun' => 'Phinx\Db\Adapter\DryRunAdapter',
     );
 
     /**

--- a/src/Phinx/Db/Adapter/DryRunAdapter.php
+++ b/src/Phinx/Db/Adapter/DryRunAdapter.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter;
+
+use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Adapter\PdoAdapter;
+use Phinx\Db\Adapter\Pdo\ReadOnlyProxyConnection;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DryRunAdapter extends AdapterWrapper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapterType()
+    {
+        return 'DryRunAdapter';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        if (!$adapter instanceof PdoAdapter) {
+            throw new \InvalidArgumentException(
+                '--dry-run is currently only supported for PDO connections'
+            );
+        }
+
+        $adapter->getOutput()->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+
+        parent::setAdapter($adapter);
+
+        $adapter->setConnection($this->getConnection());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($sql)
+    {
+        $output = $this->adapter->getOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+        $output->writeln($sql);
+        $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+        return 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTable($tableName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasColumn($tableName, $columnName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasIndex($columns, $options = array())
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasForeignKey($tableName, $columns, $constraint = null)
+    {
+        return true;
+    }
+
+    /**
+     * @return ReadOnlyProxyConnection
+     */
+    protected function getConnection()
+    {
+        return new ReadOnlyProxyConnection(
+            $this->adapter->getConnection(),
+            $this->adapter->getOutput()
+        );
+    }
+}

--- a/src/Phinx/Db/Adapter/Pdo/ProxyConnection.php
+++ b/src/Phinx/Db/Adapter/Pdo/ProxyConnection.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter\Pdo;
+
+/**
+ * PDO Proxy Connection
+ *
+ * Extends PDO to pass typehint checks and proxies calls to a separate
+ * underlying PDO instance. Useful for modifying or logging parameters
+ * or overriding normal PDO behavior.
+ * 
+ * @author Matthew Turland <me@matthewturland.com>
+ */
+class ProxyConnection extends \PDO
+{
+    /**
+     * @var \PDO
+     */
+    protected $pdo;
+
+    /**
+     * @param \PDO $pdo
+     */
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @return bool
+     */
+    public function beginTransaction()
+    {
+        return $this->pdo->beginTransaction();
+    }
+
+    /**
+     * @return bool
+     */
+    public function commit()
+    {
+        return $this->pdo->commit();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function errorCode()
+    {
+        return $this->pdo->errorCode();
+    }
+
+    /**
+     * @return array
+     */
+    public function errorInfo()
+    {
+        return $this->pdo->errorInfo();
+    }
+
+    /**
+     * @param string $statement
+     * @return int
+     */
+    public function exec($statement)
+    {
+        return $this->pdo->exec($statement);
+    }
+
+    /**
+     * @param int $attribute
+     * @return mixed
+     */
+    public function getAttribute($attribute)
+    {
+        return $this->pdo->getAttribute($attribute);
+    }
+
+    /**
+     * @return array
+     */
+    public static function getAvailableDrivers()
+    {
+        return static::getAvailableDrivers();
+    }
+
+    /**
+     * @return bool
+     */
+    public function inTransaction()
+    {
+        return $this->pdo->inTransaction();
+    }
+
+    /**
+     * @param string $name
+     * @return string
+     */
+    public function lastInsertId($name = null)
+    {
+        return $this->pdo->lastInsertId($name);
+    }
+
+    /**
+     * @param string $statement
+     * @param array $driver_options
+     * @return ProxyStatement
+     */
+    public function prepare($statement, $driver_options = null)
+    {
+        return $this->pdo->prepare($statement, $driver_options);
+    }
+
+    /**
+     * @param string $statement
+     * @return ProxyStatement
+     */
+    public function query($statement)
+    {
+        return $this->pdo->query($statement);
+    }
+
+    /**
+     * @param string $string
+     * @param int $parameter_type
+     * @return string
+     */
+    public function quote($string, $parameter_type = \PDO::PARAM_STR)
+    {
+        return $this->pdo->quote($string, $parameter_type);
+    }
+
+    /**
+     * @return bool
+     */
+    public function rollBack()
+    {
+        return $this->pdo->rollBack();
+    }
+
+    /**
+     * @param int $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function setAttribute($attribute, $value)
+    {
+        return $this->pdo->setAttribute($attribute, $value);
+    }
+}

--- a/src/Phinx/Db/Adapter/Pdo/ReadOnlyProxyConnection.php
+++ b/src/Phinx/Db/Adapter/Pdo/ReadOnlyProxyConnection.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter\Pdo;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Read-only PDO Proxy Connection
+ *
+ * Proxies read operations to an underlying PDO instance and logs write
+ * operations without executing them.
+ * 
+ * @author Matthew Turland <me@matthewturland.com>
+ */
+class ReadOnlyProxyConnection extends ProxyConnection
+{
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @param \PDO $pdo
+     * @param OutputInterface $output
+     */
+    public function __construct(\PDO $pdo, OutputInterface $output)
+    {
+        parent::__construct($pdo);
+
+        $this->output = $output;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commit()
+    {
+        return $this->rollBack();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exec($statement)
+    {
+        $verbosity = $this->output->getVerbosity();
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+        $this->output->writeln($statement);
+        $this->output->setVerbosity($verbosity);
+        return 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function prepare($statement, $driver_options = null)
+    {
+        return new ReadOnlyProxyStatement($statement, $driver_options, $this->output);
+    }
+}

--- a/src/Phinx/Db/Adapter/Pdo/ReadOnlyProxyStatement.php
+++ b/src/Phinx/Db/Adapter/Pdo/ReadOnlyProxyStatement.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter\Pdo;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Read-only PDO Proxy Statement
+ *
+ * Proxies read operations to an underlying PDOStatement instance and logs
+ * write operations without executing them.
+ * 
+ * @author Matthew Turland <me@matthewturland.com>
+ */
+class ReadOnlyProxyStatement extends \PDOStatement
+{
+    /**
+     * @var string
+     */
+    protected $statement;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @param string $statement
+     * @param array $driver_options
+     * @param OutputInterface $output
+     */
+    public function __construct(
+        $statement,
+        array $driver_options = [],
+        OutputInterface $output
+    ) {
+        $this->statement = $statement;
+        $this->output = $output;
+
+        parent::__construct($statement, $driver_options);
+    }
+
+    /**
+     * @param array $input_parameters
+     * @return bool
+     */
+    public function execute(array $input_parameters = [])
+    {
+        if (preg_match('/^select /i', $this->statement) !== 0) {
+            return parent::execute($input_parameters);
+        }
+        $sql = $this->statement;
+        while ($parameter = array_shift($input_parameters)) {
+            $index = strpos($sql, '?');
+            $sql = substr($sql, 0, $index) . $parameter . substr($sql, $index + 1);
+        }
+        $verbosity = $this->output->getVerbosity();
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+        $this->output->writeln($sql);
+        $this->output->setVerbosity($verbosity);
+        return true;
+    }
+}

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -386,7 +386,7 @@ abstract class PdoAdapter implements AdapterInterface
                 $endTime
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         } else {
             // down
             $sql = sprintf(
@@ -395,7 +395,7 @@ abstract class PdoAdapter implements AdapterInterface
                 $migration->getVersion()
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         }
 
         return $this;

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1049,7 +1049,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $endTime
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         } else {
             // down
             $sql = sprintf(
@@ -1058,7 +1058,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $migration->getVersion()
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         }
         return $this;
     }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1179,7 +1179,7 @@ SQL;
                 $endTime
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         } else {
             // down
             $sql = sprintf(
@@ -1188,7 +1188,7 @@ SQL;
                 $migration->getVersion()
             );
 
-            $this->query($sql);
+            $this->execute($sql);
         }
 
         return $this;

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -134,10 +134,11 @@ class Manager
      *
      * @param string    $environment Environment
      * @param \DateTime $dateTime    Date to migrate to
+     * @param boolean   $dryRun      Output SQL rather than executing it
      *
      * @return void
      */
-    public function migrateToDateTime($environment, \DateTime $dateTime)
+    public function migrateToDateTime($environment, \DateTime $dateTime, $dryRun)
     {
         $env            = $this->getEnvironment($environment);
         $versions       = array_keys($this->getMigrations());
@@ -159,7 +160,7 @@ class Manager
         $this->getOutput()->writeln(
             'Migrating to version ' . $earlierVersion
         );
-        return $this->migrate($environment, $earlierVersion);
+        return $this->migrate($environment, $earlierVersion, $dryRun);
     }
 
     /**
@@ -167,10 +168,11 @@ class Manager
      *
      * @param string    $environment Environment
      * @param \DateTime $dateTime    Date to roll back to
+     * @param boolean   $dryRun      Output SQL rather than executing it
      *
      * @return void
      */
-    public function rollbackToDateTime($environment, \DateTime $dateTime)
+    public function rollbackToDateTime($environment, \DateTime $dateTime, $dryRun)
     {
         $env        = $this->getEnvironment($environment);
         $versions   = $env->getVersions();
@@ -187,7 +189,7 @@ class Manager
             $laterVersion = $version;
         }
         $this->getOutput()->writeln('Rolling back to version ' . $laterVersion);
-        return $this->rollback($environment, $laterVersion);
+        return $this->rollback($environment, $laterVersion, $dryRun);
     }
 
     /**
@@ -195,9 +197,10 @@ class Manager
      *
      * @param string $environment Environment
      * @param int $version
+     * @param boolean $dryRun Output SQL rather than executing it
      * @return void
      */
-    public function migrate($environment, $version = null)
+    public function migrate($environment, $version = null, $dryRun = false)
     {
         $migrations = $this->getMigrations();
         $env = $this->getEnvironment($environment);
@@ -232,7 +235,7 @@ class Manager
                 }
 
                 if (in_array($migration->getVersion(), $versions)) {
-                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN, $dryRun);
                 }
             }
         }
@@ -244,7 +247,7 @@ class Manager
             }
 
             if (!in_array($migration->getVersion(), $versions)) {
-                $this->executeMigration($environment, $migration, MigrationInterface::UP);
+                $this->executeMigration($environment, $migration, MigrationInterface::UP, $dryRun);
             }
         }
     }
@@ -255,9 +258,10 @@ class Manager
      * @param string $name Environment Name
      * @param MigrationInterface $migration Migration
      * @param string $direction Direction
+     * @param boolean $dryRun Output SQL rather than executing it
      * @return void
      */
-    public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP)
+    public function executeMigration($name, MigrationInterface $migration, $direction = MigrationInterface::UP, $dryRun = false)
     {
         $this->getOutput()->writeln('');
         $this->getOutput()->writeln(
@@ -268,7 +272,7 @@ class Manager
 
         // Execute the migration and log the time elapsed.
         $start = microtime(true);
-        $this->getEnvironment($name)->executeMigration($migration, $direction);
+        $this->getEnvironment($name)->executeMigration($migration, $direction, $dryRun);
         $end = microtime(true);
 
         $this->getOutput()->writeln(
@@ -284,9 +288,10 @@ class Manager
      *
      * @param string $environment Environment
      * @param int $version
+     * @param boolean $dryRun Output SQL rather than executing it
      * @return void
      */
-    public function rollback($environment, $version = null)
+    public function rollback($environment, $version = null, $dryRun = false)
     {
         $migrations = $this->getMigrations();
         $env = $this->getEnvironment($environment);
@@ -330,7 +335,7 @@ class Manager
             }
 
             if (in_array($migration->getVersion(), $versions)) {
-                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                $this->executeMigration($environment, $migration, MigrationInterface::DOWN, $dryRun);
             }
         }
     }


### PR DESCRIPTION
**DO NOT MERGE**. This PR is intended only for internal peer review prior to submitting the changes upstream, assuming we do eventually decide to do so.

A few things I don't like about the current implementation, but have yet to find a way to work around:
- Manipulating the verbosity level of the `OutputInterface` instance in various areas. The core has its own output surrounding each migration that's difficult to reliably differentiate from dry run output. Because the core output would make copying and pasting the output of a dry run a lot more troublesome, the current approach simply changes the output verbosity level to squelch the core output.
- Coupling `ReadOnlyProxyStatement` to `OutputInterface`. The alternative is to duplicate the code to manipulate output verbosity levels in `DryRunAdapter`, which would require overriding most if not all of the methods of `AdapterWrapper` to be able to call that code.
- Coupling `ReadOnlyProxyConnection` to `OutputInterface`. This is the best way I've found to make this interoperable with the rest of the core while still supporting the output of generated SQL statements.

Refs robmorgan/phinx#567
